### PR TITLE
Add clj-kondo exported configuration for the deftransformer macro + hygiene

### DIFF
--- a/.clj-kondo/blak3mill3r/noah/config.edn
+++ b/.clj-kondo/blak3mill3r/noah/config.edn
@@ -1,0 +1,1 @@
+../../../resources/clj-kondo.exports/blak3mill3r/noah/config.edn

--- a/.clj-kondo/blak3mill3r/noah/hooks/noah.clj
+++ b/.clj-kondo/blak3mill3r/noah/hooks/noah.clj
@@ -1,0 +1,1 @@
+../../../../resources/clj-kondo.exports/blak3mill3r/noah/hooks/noah.clj

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["blak3mill3r/noah"]}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,3 @@
-{:config-paths ["blak3mill3r/noah"]}
+{:config-paths ["blak3mill3r/noah"]
+ :lint-as {com.rpl.specter/defnav clojure.core/defn
+           com.rpl.specter/defmacroalias clojure.core/defn}}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /.idea
 /*.iml
 .cpcache
+/.clj-kondo/.cache/

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,8 @@
 ;; -*- mode: clojure; eval: (flycheck-mode -1); -*-
 
-{:aliases
+{:paths ["src" "resources"]
+
+ :aliases
  {:test
   {:extra-paths ["test" "classes"]
    :extra-deps

--- a/resources/clj-kondo.exports/blak3mill3r/noah/config.edn
+++ b/resources/clj-kondo.exports/blak3mill3r/noah/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {noah.transformer/deftransformer hooks.noah/deftransformer}}}

--- a/resources/clj-kondo.exports/blak3mill3r/noah/hooks/noah.clj
+++ b/resources/clj-kondo.exports/blak3mill3r/noah/hooks/noah.clj
@@ -1,0 +1,60 @@
+(ns hooks.noah
+  (:refer-clojure :exclude [with-bindings])
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn- with-bindings
+  [bindings body]
+  (api/list-node
+   (list*
+    (api/token-node 'let)
+    bindings
+    body)))
+
+(defn deftransformer
+  [{:keys [node]}]
+  (let [[name & more] (rest (:children node))
+        [_docstring store-names & more]
+        (if (api/string-node? (first more))
+          more
+          (cons nil more))
+        [schedules more] (loop [schedules '()
+                                more more]
+                           (if (and (api/keyword-node? (first more))
+                                    (= (api/sexpr (first more)) :schedule))
+                             (recur (concat schedules (map (partial nth more) (range 1 4)))
+                                    (nthrest more 4))
+                             [schedules more]))
+        [init more] (if (and (api/keyword-node? (first more))
+                             (= (api/sexpr (first more)) :init))
+                      [(second more) (nthrest more 2)]
+                      [(api/token-node nil) more])
+        [close [params & body]] (if (and (api/keyword-node? (first more))
+                                         (= (api/sexpr (first more)) :close))
+                                  [(second more) (nthrest more 2)]
+                                  [(api/token-node nil) more])
+        with-stores (fn [& body]
+                      (with-bindings
+                        (api/vector-node
+                         (interleave (:children store-names) (repeat (api/token-node nil))))
+                        body))
+        new-node (api/list-node
+                  (list
+                   (api/token-node 'def)
+                   name
+                   (api/list-node
+                    (list
+                     (api/token-node 'do)
+                     init
+                     close
+                     (apply with-stores
+                            schedules
+                            (api/list-node
+                             (list*
+                              (api/token-node 'fn)
+                              (api/token-node (symbol (str (api/sexpr name) "-transform")))
+                              params
+                              body)))
+                     schedules
+                     (api/token-node nil)))))]
+    {:node new-node}))

--- a/src/noah/transduce.clj
+++ b/src/noah/transduce.clj
@@ -79,7 +79,7 @@
          nil
          (fn [k v]
            (let [step-fn (value-transform-step k)
-                 context tr/*context*
+                 context (tr/context)
                  g (or @theglue (let [v (new-gluer state-store-name context)] (vreset! theglue v) v))]
              (init! g k initial-state)
              (binding [csc/*state* (fn [_] (yield-state! g k))]

--- a/src/noah/transformer.clj
+++ b/src/noah/transformer.clj
@@ -77,7 +77,7 @@
   (let [{:keys [name docstring store-names schedules init close params+body]} (s/conform ::deftransformer-args args)]
     `(def ~name ~@(when docstring [docstring])
        (reify TransformerSupplier
-         (get [~'this]
+         (get [_#]
            (->NoahTransformer
             ~(:fn init) ;; FIXME wrap with bindings?
             (fn ~(symbol (str name"-transform"))

--- a/src/noah/transformer.clj
+++ b/src/noah/transformer.clj
@@ -80,7 +80,7 @@
          (get [_#]
            (->NoahTransformer
             ~(:fn init) ;; FIXME wrap with bindings?
-            (fn ~(symbol (str name"-transform"))
+            (fn ~name
               ~@(wrap-with-bindings store-names params+body))
             ~(:fn close) ;; FIXME wrap with bindings?
             ~(->> schedules (transform [ALL :fn] #(wrap-fn-with-bindings store-names %)))


### PR DESCRIPTION
This PR adds exported clj-kondo hooks for the `deftransformer` macro, as well as removing several unhygienic symbols which were previously exposed.