### PR TITLE
Nippy: do not serialize clojure metadata

### DIFF
--- a/src/noah/serdes.clj
+++ b/src/noah/serdes.clj
@@ -20,7 +20,7 @@
   (serialize [_ _ data] (nippy/freeze data opts))
   (close [_]))
 
-(def the-nippy-serializer (NippySerializer. {}))
+(def the-nippy-serializer (NippySerializer. {:incl-metadata? false})) ;; TODO:(Blake) allow the user to configure this
 (def the-nippy-deserializer (NippyDeserializer. {}))
 
 (deftype NippySerde []


### PR DESCRIPTION
this seems like a sensible default, because metadata can be used
effectively to keep additional data about a value that may be too
large to send over the wire

without metadata, it can be tricky to use the KStreams DSL API
effectively

I will make this user-configurable in the future; for now it makes
sense to disable it for our needs